### PR TITLE
Add our security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+# Vox Pupuli Security Policy
+
+Our vulnerabilities reporting process is at https://voxpupuli.org/security/


### PR DESCRIPTION
We currently distribute it across all Puppet modules. It looks like we can configure it on an org level:
* https://github.com/github/cvelist has the security tab with a policy
* it has no own SECURITY.md
* https://github.com/github/.github/blob/master/SECURITY.md has a policy